### PR TITLE
Feature/payment protocol setup

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(qbt_base STATIC
     utils/password.h
     utils/random.h
     utils/string.h
+    payfluxo/payfluxo.h
     utils/version.h
     version.h
 
@@ -161,7 +162,7 @@ add_library(qbt_base STATIC
     utils/password.cpp
     utils/random.cpp
     utils/string.cpp
-)
+    payfluxo/payfluxo.cpp)
 
 target_link_libraries(qbt_base
     PRIVATE

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -437,6 +437,7 @@ Session::Session(QObject *parent)
     , m_peerTurnoverInterval(BITTORRENT_SESSION_KEY("PeerTurnoverInterval"), 300)
     , m_userDecryptedCertificateString(BITTORRENT_KEY("UserDecryptedCertificateString"), nullptr)
     , m_userDecryptedPrivateKeyString(BITTORRENT_KEY("UserDecryptedPrivateKeyString"), nullptr)
+    , m_userMSPIdString(BITTORRENT_KEY("UserMSPIdString"), nullptr)
     , m_bannedIPs("State/BannedIPs"
                   , QStringList()
                   , [](const QStringList &value)
@@ -946,6 +947,20 @@ void Session::setUserDecryptedCertificateString(const QString val)
         return;
 
     m_userDecryptedCertificateString = val;
+    configureDeferred();
+}
+
+QString Session::userMSPIdString() const
+{
+    return m_userMSPIdString;
+}
+
+void Session::setUserMSPIdString(const QString val)
+{
+    if (val == m_userMSPIdString)
+        return;
+
+    m_userMSPIdString = val;
     configureDeferred();
 }
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1834,6 +1834,16 @@ void Session::banIP(const QString &ip)
     }
 }
 
+void Session::unbanIP(const QString& ip)
+{
+    QStringList bannedIPs = m_bannedIPs;
+    if (bannedIPs.contains(ip))
+    {
+        bannedIPs.removeAll(ip);
+        setBannedIPs(bannedIPs);
+    }
+}
+
 // Delete a torrent from the session, given its hash
 // and from the disk, if the corresponding deleteOption is chosen
 bool Session::deleteTorrent(const TorrentID &id, const DeleteOption deleteOption)

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -272,6 +272,8 @@ namespace BitTorrent
         void setTorrentContentLayout(TorrentContentLayout value);
         bool isTrackerEnabled() const;
         void setTrackerEnabled(bool enabled);
+        QString userMSPIdString() const;
+        void setUserMSPIdString(const QString val);
         QString userDecryptedCertificateString() const;
         void setUserDecryptedCertificateString(QString val);
         QString userDecryptedPrivateKeyString() const;
@@ -740,6 +742,7 @@ namespace BitTorrent
         CachedSettingValue<int> m_peerTurnoverInterval;
         CachedSettingValue<QString> m_userDecryptedCertificateString;
         CachedSettingValue<QString> m_userDecryptedPrivateKeyString;
+        CachedSettingValue<QString> m_userMSPIdString;
         CachedSettingValue<QStringList> m_bannedIPs;
 #if defined(Q_OS_WIN)
         CachedSettingValue<OSMemoryPriority> m_OSMemoryPriority;

--- a/src/base/bittorrent/session.h
+++ b/src/base/bittorrent/session.h
@@ -455,6 +455,7 @@ namespace BitTorrent
         void setMaxRatioAction(MaxRatioAction act);
 
         void banIP(const QString &ip);
+        void unbanIP(const QString& ip);
 
         bool isKnownTorrent(const TorrentID &id) const;
         bool addTorrent(const QString &source, const AddTorrentParams &params = AddTorrentParams());

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1942,10 +1942,26 @@ void TorrentImpl::handleAppendExtensionToggled()
     manageIncompleteFiles();
 }
 
+void TorrentImpl::handleBlockFinishedAlert(const lt::block_finished_alert* p)
+{
+    //pay(ip, this->file_size, this->unique_identifier);
+}
+
+void TorrentImpl::handleBlockUploadedAlert(const lt::block_uploaded_alert* p)
+{
+    //banIP();
+}
+
 void TorrentImpl::handleAlert(const lt::alert *a)
 {
     switch (a->type())
     {
+    case lt::block_finished_alert::alert_type:
+        handleBlockFinishedAlert(static_cast<const lt::block_finished_alert*>(a));
+        break;
+    case lt::block_uploaded_alert::alert_type:
+        handleBlockUploadedAlert(static_cast<const lt::block_uploaded_alert*>(a));
+        break;
     case lt::file_renamed_alert::alert_type:
         handleFileRenamedAlert(static_cast<const lt::file_renamed_alert*>(a));
         break;

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -279,6 +279,9 @@ namespace BitTorrent
         void handleTrackerReplyAlert(const lt::tracker_reply_alert *p);
         void handleTrackerWarningAlert(const lt::tracker_warning_alert *p);
 
+        void handleBlockFinishedAlert(const lt::block_finished_alert* p);
+        void handleBlockUploadedAlert(const lt::block_uploaded_alert* p);
+
         bool isMoveInProgress() const;
 
         void setAutoManaged(bool enable);

--- a/src/base/payfluxo/payfluxo.h
+++ b/src/base/payfluxo/payfluxo.h
@@ -1,0 +1,5 @@
+namespace Payfluxo {
+    class Payfluxo {
+
+    };
+}

--- a/src/gui/authdialog.cpp
+++ b/src/gui/authdialog.cpp
@@ -111,6 +111,7 @@ void AuthDialog::setCredentials()
         // transform inputJson in char*:
         std::string certificateString = fastWriter.write(certificateJson["credentials"]["certificate"]);
         std::string privateKeyString = fastWriter.write(certificateJson["credentials"]["privateKey"]);
+        std::string mspIdString = fastWriter.write(certificateJson["mspId"]);
 
         if(certificateString.compare("null\n") == 0){
             throw INVALID_CREDENTIALS_EXCEPTION;
@@ -118,6 +119,7 @@ void AuthDialog::setCredentials()
 
         BitTorrent::Session::instance()->setUserDecryptedPrivateKeyString(QString::fromUtf8(privateKeyString.c_str()));
         BitTorrent::Session::instance()->setUserDecryptedCertificateString(QString::fromUtf8(certificateString.c_str()));
+        BitTorrent::Session::instance()->setUserMSPIdString(QString::fromUtf8(mspIdString.c_str()));
         
         QApplication::restoreOverrideCursor();
         this->toggleWidgetsEnable();

--- a/src/gui/balancedialog.cpp
+++ b/src/gui/balancedialog.cpp
@@ -68,6 +68,7 @@ void BalanceDialog::flushCredentials()
 {
     BitTorrent::Session::instance()->setUserDecryptedPrivateKeyString(nullptr);
     BitTorrent::Session::instance()->setUserDecryptedCertificateString(nullptr);
+    BitTorrent::Session::instance()->setUserMSPIdString(nullptr);
 
     this->close();
 }


### PR DESCRIPTION
# What does this PR do

- Add MSPId as stored data from a login session;
- Add unban ip auxiliary method for Bittorrent sessions
- Setups the pipeline for recocgnizing when must pay and when must block when not paid.