### PR TITLE
Feature/notification connection

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,7 @@ set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
 find_package(Boost ${minBoostVersion} REQUIRED)
 find_package(OpenSSL ${minOpenSSLVersion} REQUIRED)
 find_package(ZLIB ${minZlibVersion} REQUIRED)
-find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS Core Network Xml LinguistTools)
+find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS Core Network Xml LinguistTools WebSockets)
 find_package(jsoncpp REQUIRED)
 find_package(lyra2-file-encryptor REQUIRED)
 

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -137,15 +137,15 @@ Application::Application(int &argc, char **argv)
     qRegisterMetaType<Log::Msg>("Log::Msg");
     qRegisterMetaType<Log::Peer>("Log::Peer");
 
-    setApplicationName("qBittorrent");
-    setOrganizationDomain("qbittorrent.org");
+    setApplicationName("Torrente");
+    setOrganizationDomain("Biobank.org");
 #if !defined(DISABLE_GUI)
-    setDesktopFileName("org.qbittorrent.qBittorrent");
+    setDesktopFileName("org.Biobank.Torrente");
     setAttribute(Qt::AA_UseHighDpiPixmaps, true);  // opt-in to the high DPI pixmap support
     setQuitOnLastWindowClosed(false);
     QPixmapCache::setCacheLimit(PIXMAP_CACHE_SIZE);
 #endif
-
+   
     const bool portableModeEnabled = m_commandLineArgs.profileDir.isEmpty()
             && QDir(QCoreApplication::applicationDirPath()).exists(DEFAULT_PORTABLE_MODE_PROFILE_DIR);
 

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(qbt_base STATIC
     utils/random.h
     utils/string.h
     payfluxo/payfluxo.h
+    payfluxo/payfluxonotification.h
     utils/version.h
     version.h
 
@@ -162,7 +163,8 @@ add_library(qbt_base STATIC
     utils/password.cpp
     utils/random.cpp
     utils/string.cpp
-    payfluxo/payfluxo.cpp)
+    payfluxo/payfluxo.cpp
+    payfluxo/payfluxonotification.cpp)
 
 target_link_libraries(qbt_base
     PRIVATE
@@ -170,7 +172,7 @@ target_link_libraries(qbt_base
         ZLIB::ZLIB
     PUBLIC
         LibtorrentRasterbar::torrent-rasterbar
-        Qt5::Core Qt5::Network Qt5::Xml
+        Qt5::Core Qt5::Network Qt5::Xml Qt5::WebSockets
         qbt_common_cfg
 )
 

--- a/src/base/payfluxo/payfluxonotification.cpp
+++ b/src/base/payfluxo/payfluxonotification.cpp
@@ -1,0 +1,59 @@
+#include "payfluxonotification.h"
+#include "base/bittorrent/session.h"
+
+#include <QWebSocket>
+#include <QUrl>
+#include <QObject>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+
+PayfluxoNotification::PayfluxoNotification( bool debug, QObject* parent)
+    : QObject(parent)
+    , m_debug(debug)
+{
+    QUrl url("ws://127.0.0.1:7933");
+
+    if (m_debug)
+        qDebug() << "WebSocket server:" << url;
+    connect(&m_webSocket, &QWebSocket::connected, this, &PayfluxoNotification::onConnected);
+    connect(&m_webSocket, &QWebSocket::disconnected, this, &PayfluxoNotification::closed);
+    m_webSocket.open(url);
+}
+
+void PayfluxoNotification::onConnected()
+{
+    if (m_debug)
+        qDebug() << "WebSocket connected";
+    connect(&m_webSocket, &QWebSocket::textMessageReceived,
+        this, &PayfluxoNotification::onTextMessageReceived);
+    
+}
+
+void PayfluxoNotification::closed() {
+
+}
+
+void PayfluxoNotification::handlePaymentNotification(QString ip)
+{
+    BitTorrent::Session::instance()->unbanIP(ip);
+}
+
+void PayfluxoNotification::onTextMessageReceived(QString message)
+{
+    QJsonDocument jsonResponse = QJsonDocument::fromJson(message.toUtf8());
+    QJsonObject jsonObject = jsonResponse.object();
+    QString type = jsonObject["type"].toString();    
+    int typeComparison = QString::compare(type, "PaymentNotification", Qt::CaseSensitive);
+    QJsonObject dataJson = jsonObject["data"].toObject();
+
+    if (typeComparison == 0) {
+        this->handlePaymentNotification(dataJson["ip"].toString());
+    }
+    
+    if (m_debug)
+        qDebug() << "Message received:" << message;
+    
+}
+
+

--- a/src/base/payfluxo/payfluxonotification.h
+++ b/src/base/payfluxo/payfluxonotification.h
@@ -1,0 +1,21 @@
+#ifndef PAYFLUXONOTIFICATION_H
+#define PAYFLUXONOTIFICATION_H
+
+#include <QWebSocket>
+
+class PayfluxoNotification : public QObject {
+
+private:
+    bool m_debug;
+    QWebSocket m_webSocket;
+
+public:
+    explicit PayfluxoNotification(bool debug, QObject* parent);
+    void onConnected();
+    void closed();
+    void handlePaymentNotification(QString ip);
+    void onTextMessageReceived(QString message);
+    
+};
+#endif 
+

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -71,6 +71,7 @@
 #include "base/utils/misc.h"
 #include "base/utils/password.h"
 #include "base/version.h"
+#include "base/payfluxo/payfluxonotification.h"
 #include "aboutdialog.h"
 #include "addnewtorrentdialog.h"
 #include "autoexpandabledialog.h"
@@ -203,7 +204,8 @@ MainWindow::MainWindow(QWidget *parent)
     lockMenu->addAction(tr("&Set Password"), this, &MainWindow::defineUILockPassword);
     lockMenu->addAction(tr("&Clear Password"), this, &MainWindow::clearUILockPassword);
     m_ui->actionLock->setMenu(lockMenu);
-    
+
+    this->payfluxoNotification = new PayfluxoNotification(false, this);
 
     this->refreshAuthenticationState();
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -203,14 +203,7 @@ MainWindow::MainWindow(QWidget *parent)
     lockMenu->addAction(tr("&Set Password"), this, &MainWindow::defineUILockPassword);
     lockMenu->addAction(tr("&Clear Password"), this, &MainWindow::clearUILockPassword);
     m_ui->actionLock->setMenu(lockMenu);
-
-    QAction *loginUserAct = lockMenu->addAction(tr("&Login"));
-    connect(loginUserAct, &QAction::triggered, this, &MainWindow::defineUIAuth);
-    m_ui->actionAuth->setMenu(lockMenu);
-
-    QAction *balanceAct = lockMenu->addAction(tr("&Check balance"));
-    connect(balanceAct, &QAction::triggered, this, &MainWindow::defineUIUserPanel);
-    m_ui->actionBalance->setMenu(lockMenu);
+    
 
     this->refreshAuthenticationState();
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -27,7 +27,7 @@
  */
 
 #pragma once
-
+#include "base/payfluxo/payfluxonotification.h"
 #include <QMainWindow>
 #include <QPointer>
 
@@ -266,4 +266,6 @@ private:
 
     QTimer *m_programUpdateTimer = nullptr;
 #endif
+
+    PayfluxoNotification *payfluxoNotification;
 };


### PR DESCRIPTION
# What does this PR do

- Fix auth dialog cases showing on view tab;
- Add QtWebSockets dependency to the project;
- Tried to change application name, but got no graphical result;
- Got payfluxo websocket connection interface and handlers;
- Integrated Payfluxo to the overall application;

## Results

- Could send a json from Payfluxo application via websocket to the Torrente and could channel it to the unban ip method.