### PR TITLE
Feature/integrate download intention

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -85,6 +85,7 @@
 #include "base/utils/net.h"
 #include "base/utils/random.h"
 #include "base/version.h"
+#include "base/payfluxo/payfluxo.h"
 #include "bandwidthscheduler.h"
 #include "common.h"
 #include "customstorage.h"
@@ -4623,6 +4624,18 @@ void Session::createTorrent(const lt::torrent_handle &nativeHandle)
     // Send new torrent signal
     if (!params.restored)
         emit torrentAdded(torrent);
+
+    // Case authenticated, send download intention.
+    if (Payfluxo::Session::instance()->isAuthenticated())
+    {
+        Payfluxo::Session* payfluxoSession = Payfluxo::Session::instance();
+        torrent->pause();
+        payfluxoSession->declareDownloadIntention(
+            torrent->createMagnetURI(),
+            torrent->piecesCount(),
+            torrent->id().toString()
+        );
+    }
 
     // Torrent could have error just after adding to libtorrent
     if (torrent->hasError())

--- a/src/base/payfluxo/payfluxo.cpp
+++ b/src/base/payfluxo/payfluxo.cpp
@@ -144,4 +144,8 @@ void Session::setRedeemableCoins(float newAmount) {
     m_redeemableCoins = newAmount;
 }
 
+void Session::declareDownloadIntention(QString magneticLink, int piecesNumber, QString torrentId) {
+    m_payfluxoService->sendDownloadIntentionMessage(magneticLink, piecesNumber, torrentId);
+}
+
 Session* Session::m_instance = nullptr;

--- a/src/base/payfluxo/payfluxo.h
+++ b/src/base/payfluxo/payfluxo.h
@@ -17,6 +17,8 @@ namespace Payfluxo {
         int  getIpPendentPayment(QString ip);
         bool ipExceededPendentPayment(QString ip);
 
+        void declareDownloadIntention(QString magneticLink, int piecesNumber, QString torrentId);
+
         float getAvailableCoins();
         float getFrozenCoins();
         float getRedeemableCoins();

--- a/src/base/payfluxo/payfluxoservice.h
+++ b/src/base/payfluxo/payfluxoservice.h
@@ -16,10 +16,12 @@ public:
     void closed();
     void onWebSocketError(QAbstractSocket::SocketError error);
     void handlePaymentNotification(QString ip);
+    void handleIntentionDeclaredNotification(QString torrentIdString, int status);
     void onTextMessageReceived(QString message);
     void sendBlockDownloadedMessage(QString ip, QString torrentId, QString fileSize);
     void sendAuthenticatedMessage(QString certificate, QString privateKey, QString orgMSP);
     void sendDeauthMessage();
+    void sendDownloadIntentionMessage(QString magneticLink, int piecesNumber, QString torrentId);
     void sendCloseMessage();
 };
 #endif


### PR DESCRIPTION
# What does this PR do?

- Integrate download intention declaration;
  - Pauses a torrent as soon as it is added if authenticated;
  - If authenticated, if add a torrent to queue, sends message to payfluxo;
  - Resumes torrent session as soon the download declaration is approved by notification;