### PR TITLE
Featuer/discriminate paid torrents

### DIFF
--- a/src/base/bittorrent/torrent.h
+++ b/src/base/bittorrent/torrent.h
@@ -289,6 +289,9 @@ namespace BitTorrent
         virtual bool connectPeer(const PeerAddress &peerAddress) = 0;
         virtual void clearPeers() = 0;
 
+        virtual void turnTorrentPaid() = 0;
+        virtual bool isPaidTorrent() = 0;
+
         virtual QString createMagnetURI() const = 0;
 
         TorrentID id() const;

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1964,6 +1964,7 @@ void TorrentImpl::handleAppendExtensionToggled()
 
 void TorrentImpl::handleBlockFinishedAlert(const lt::block_finished_alert* p)
 {
+    // Paid handler;
     if (Payfluxo::Session::instance()->isAuthenticated()) {
         PayfluxoService* service = Payfluxo::Session::instance()->getService();
         service->sendBlockDownloadedMessage(
@@ -1976,6 +1977,7 @@ void TorrentImpl::handleBlockFinishedAlert(const lt::block_finished_alert* p)
 
 void TorrentImpl::handleBlockUploadedAlert(const lt::block_uploaded_alert* p)
 {
+    // Paid handler;
     if (Payfluxo::Session::instance()->isAuthenticated()) {
         QString downloaderIp = QString::fromStdString(p->endpoint.address().to_string());
 
@@ -1984,6 +1986,7 @@ void TorrentImpl::handleBlockUploadedAlert(const lt::block_uploaded_alert* p)
 }
 
 void TorrentImpl::handleIncomingRequestAlert(const lt::incoming_request_alert* p){
+    // Paid handler;
     if (Payfluxo::Session::instance()->isAuthenticated()) {
         QString requesterIp = QString::fromStdString(p->endpoint.address().to_string());
 

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -262,6 +262,8 @@ TorrentImpl::TorrentImpl(Session *session, lt::session *nativeSession
     , m_isStopped(params.paused)
     , m_ltAddTorrentParams(params.ltAddTorrentParams)
 {
+    m_paidTorrent = false;
+
     if (m_useAutoTMM)
         m_savePath = Utils::Fs::toNativePath(m_session->categorySavePath(m_category));
 
@@ -435,6 +437,16 @@ void TorrentImpl::setAutoTMMEnabled(bool enabled)
 QString TorrentImpl::actualStorageLocation() const
 {
     return QString::fromStdString(m_nativeStatus.save_path);
+}
+
+void TorrentImpl::turnTorrentPaid()
+{
+    m_paidTorrent = true;
+}
+
+bool TorrentImpl::isPaidTorrent()
+{
+    return m_paidTorrent;
 }
 
 void TorrentImpl::setAutoManaged(const bool enable)
@@ -1522,36 +1534,42 @@ void TorrentImpl::pause()
 
 void TorrentImpl::resume(const TorrentOperatingMode mode)
 {
-    if (hasError())
-        m_nativeHandle.clear_error();
-
-    m_operatingMode = mode;
-
-    if (m_hasMissingFiles)
+    // Don't let the torrent be resumed if it's a paid torrent and user is unauthenticated
+    bool userIsAuthenticated = Payfluxo::Session::instance()->isAuthenticated();
+    bool letResumeCondition = (userIsAuthenticated || !this->m_paidTorrent);
+    if (letResumeCondition)
     {
-        m_hasMissingFiles = false;
-        m_isStopped = false;
-        m_ltAddTorrentParams.ti = std::const_pointer_cast<lt::torrent_info>(m_nativeHandle.torrent_file());
-        reload();
-        updateStatus();
-        return;
-    }
+        if (hasError())
+            m_nativeHandle.clear_error();
 
-    if (m_isStopped)
-    {
-        // Torrent may have been temporarily resumed to perform checking files
-        // so we have to ensure it will not pause after checking is done.
-        m_nativeHandle.unset_flags(lt::torrent_flags::stop_when_ready);
+        m_operatingMode = mode;
 
-        m_isStopped = false;
-        m_session->handleTorrentResumed(this);
-    }
+        if (m_hasMissingFiles)
+        {
+            m_hasMissingFiles = false;
+            m_isStopped = false;
+            m_ltAddTorrentParams.ti = std::const_pointer_cast<lt::torrent_info>(m_nativeHandle.torrent_file());
+            reload();
+            updateStatus();
+            return;
+        }
 
-    if (m_maintenanceJob == MaintenanceJob::None)
-    {
-        setAutoManaged(m_operatingMode == TorrentOperatingMode::AutoManaged);
-        if (m_operatingMode == TorrentOperatingMode::Forced)
-            m_nativeHandle.resume();
+        if (m_isStopped)
+        {
+            // Torrent may have been temporarily resumed to perform checking files
+            // so we have to ensure it will not pause after checking is done.
+            m_nativeHandle.unset_flags(lt::torrent_flags::stop_when_ready);
+
+            m_isStopped = false;
+            m_session->handleTorrentResumed(this);
+        }
+
+        if (m_maintenanceJob == MaintenanceJob::None)
+        {
+            setAutoManaged(m_operatingMode == TorrentOperatingMode::AutoManaged);
+            if (m_operatingMode == TorrentOperatingMode::Forced)
+                m_nativeHandle.resume();
+        }
     }
 }
 

--- a/src/base/bittorrent/torrentimpl.h
+++ b/src/base/bittorrent/torrentimpl.h
@@ -256,6 +256,9 @@ namespace BitTorrent
 
         QString actualStorageLocation() const;
 
+        void turnTorrentPaid();
+        bool isPaidTorrent();
+
     private:
         typedef std::function<void ()> EventTrigger;
 
@@ -336,6 +339,8 @@ namespace BitTorrent
         bool m_hasFirstLastPiecePriority = false;
         bool m_useAutoTMM;
         bool m_isStopped;
+
+        bool m_paidTorrent = false;
 
         bool m_unchecked = false;
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(qbt_gui STATIC
     log/logmodel.h
     mainwindow.h
     optionsdialog.h
+    paychoicedialog.h
     powermanagement/powermanagement.h
     previewlistdelegate.h
     previewselectdialog.h
@@ -111,6 +112,7 @@ add_library(qbt_gui STATIC
     log/logmodel.cpp
     mainwindow.cpp
     optionsdialog.cpp
+    paychoicedialog.cpp
     powermanagement/powermanagement.cpp
     previewlistdelegate.cpp
     previewselectdialog.cpp
@@ -183,6 +185,7 @@ add_library(qbt_gui STATIC
     ipsubnetwhitelistoptionsdialog.ui
     mainwindow.ui
     optionsdialog.ui
+    paychoicedialog.ui
     previewselectdialog.ui
     properties/peersadditiondialog.ui
     properties/propertieswidget.ui

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -774,7 +774,6 @@ void MainWindow::on_actionBalance_triggered()
                 if (torrents[index]->isPaidTorrent())
                     torrents[index]->pause();
             }
-            
         }
         this->refreshAuthenticationState();
     }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -761,12 +761,9 @@ void MainWindow::on_actionAuth_triggered()
 
 void MainWindow::on_actionBalance_triggered()
 {
-    bool authStateBefore = Payfluxo::Session::instance()->isAuthenticated();
     if(defineUIUserPanel())
     {
-        bool authStateAfter = Payfluxo::Session::instance()->isAuthenticated();
-        // logout?
-        if (authStateAfter != authStateBefore)
+        if (Payfluxo::Session::instance()->isAuthenticated())
         {
             QVector<BitTorrent::Torrent *> torrents = BitTorrent::Session::instance()->torrents();
             for (int index = 0; index < torrents.length(); index++)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -667,6 +667,8 @@ bool MainWindow::defineUIDecrypt()
     DecypherDialog decryptDialog(this);
 
     decryptDialog.exec();
+
+    return true;
 }
 
 bool MainWindow::defineUIPayChoice(QVector<BitTorrent::Torrent*> notPaidTorrents)

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -744,6 +744,7 @@ void MainWindow::on_actionAuth_triggered()
                     notPaidTorrents.append(torrents[index]);
                 else
                 {
+                    torrents[index]->turnTorrentPaid();
                     Payfluxo::Session::instance()->declareDownloadIntention(
                         torrents[index]->createMagnetURI(),
                         torrents[index]->piecesCount(),

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -117,6 +117,7 @@ private slots:
     bool defineUILockPassword();
     bool defineUIDecrypt();
     bool defineUIAuth();
+    bool defineUIPayChoice(QVector<BitTorrent::Torrent*> notPaidTorrents);
     bool defineUIUserPanel();
     void clearUILockPassword();
     bool unlockUI();

--- a/src/gui/paychoicedialog.cpp
+++ b/src/gui/paychoicedialog.cpp
@@ -1,0 +1,101 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2013  Nick Tiskov <daymansmail@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#include <QFileDialog>
+#include <QListWidget>
+#include <QApplication>
+#include <QMessageBox>
+
+#include "base/bittorrent/session.h"
+#include "base/payfluxo/payfluxo.h"
+#include "base/bittorrent/torrent.h"
+#include "base/bittorrent/torrentimpl.h"
+#include "base/bittorrent/infohash.h"
+
+#include "paychoicedialog.h"
+
+#include "ui_paychoicedialog.h"
+#include "utils.h"
+
+#include <iostream>
+#include <string>
+
+PayChoiceDialog::PayChoiceDialog(QWidget* parent, QVector<BitTorrent::Torrent *> notPaidTorrents)
+    : QDialog(parent)
+    , m_ui(new Ui::PayChoiceDialog)
+{
+    m_ui->setupUi(this);
+
+    QStringList torrentsNames;
+
+    torrentOptions = notPaidTorrents;
+
+    int amountOfTorrents = notPaidTorrents.count();
+    for (int index = 0; index < amountOfTorrents; index++)
+    {
+        torrentsNames << notPaidTorrents[index]->name();
+    }
+
+    m_ui->torrentChoices->addItems(torrentsNames);
+
+    QListWidgetItem* item = 0;
+    for (int i = 0; i < m_ui->torrentChoices->count(); ++i) {
+        item = m_ui->torrentChoices->item(i);
+        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+        item->setCheckState(Qt::Unchecked);
+    }
+
+    m_ui->SelectButton->setText(tr("Select"));
+    this->setWindowTitle(tr("Convert torrents to paid mode"));
+}
+
+PayChoiceDialog::~PayChoiceDialog()
+{
+    delete m_ui;
+}
+
+
+void PayChoiceDialog::onSelectButtonClicked()
+{
+    QListWidgetItem* item = 0;
+    for (int i = 0; i < m_ui->torrentChoices->count(); ++i) {
+        item = m_ui->torrentChoices->item(i);
+        Qt::CheckState torrentState = item->checkState();
+        if (torrentState == Qt::CheckState::Checked)
+        {
+            torrentOptions[i]->turnTorrentPaid();
+            Payfluxo::Session::instance()->declareDownloadIntention(
+                torrentOptions[i]->createMagnetURI(),
+                torrentOptions[i]->piecesCount(),
+                torrentOptions[i]->id().toString()
+            );
+        }
+    }
+
+    this->close();
+}

--- a/src/gui/paychoicedialog.h
+++ b/src/gui/paychoicedialog.h
@@ -1,0 +1,60 @@
+/*
+ * Bittorrent Client using Qt and libtorrent.
+ * Copyright (C) 2013  Nick Tiskov <daymansmail@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link this program with the OpenSSL project's "OpenSSL" library (or with
+ * modified versions of it that use the same license as the "OpenSSL" library),
+ * and distribute the linked executables. You must obey the GNU General Public
+ * License in all respects for all of the code used other than "OpenSSL".  If you
+ * modify file(s), you may extend this exception to your version of the file(s),
+ * but you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+#ifndef PAYCHOICEDIALOG_H
+#define PAYCHOICEDIALOG_H
+
+#include <QDialog>
+#include <QLineEdit>
+
+#include "base/bittorrent/torrent.h"
+
+class QString;
+
+namespace Ui
+{
+    class PayChoiceDialog;
+}
+
+class PayChoiceDialog final : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit PayChoiceDialog(QWidget* parent, QVector<BitTorrent::Torrent *> notPaidTorrents);
+    ~PayChoiceDialog();
+
+private slots:
+    void onSelectButtonClicked();
+
+private:
+    Ui::PayChoiceDialog* m_ui;
+    QVector<BitTorrent::Torrent*> torrentOptions;
+};
+
+#endif // AUTHDIALOG_H

--- a/src/gui/paychoicedialog.ui
+++ b/src/gui/paychoicedialog.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PayChoiceDialog</class>
+ <widget class="QDialog" name="PayChoiceDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>374</width>
+    <height>282</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>374</width>
+    <height>282</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>PayChoiceDialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QListWidget" name="torrentChoices">
+     <property name="minimumSize">
+      <size>
+       <width>300</width>
+       <height>180</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>350</width>
+       <height>200</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QPushButton" name="SelectButton">
+     <property name="minimumSize">
+      <size>
+       <width>290</width>
+       <height>50</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>290</width>
+       <height>50</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Select</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections>
+ <connection>
+   <sender>SelectButton</sender>
+   <signal>clicked()</signal>
+   <receiver>PayChoiceDialog</receiver>
+   <slot>onSelectButtonClicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>220</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>216</x>
+     <y>150</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
# What does this PR do?

- add the property `paidTorrent` to torrentImpl and equips it with appropriate getter and setter;
- add rule for torrent resume to only let it be unpaused if it's an unpaid torrent or if user is authenticated;
- add a paychoice dialog that pops up when user authenticates and there are unpaid torrents on queue. It will ask with a checkbox for the user to choose those that he want to be paid;
- add rule for pausing all paid torrents on user logout;