### PR TITLE
Bugfix/second test

### DIFF
--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -4644,11 +4644,14 @@ void Session::createTorrent(const lt::torrent_handle &nativeHandle)
         Payfluxo::Session* payfluxoSession = Payfluxo::Session::instance();
         torrent->pause();
         torrent->turnTorrentPaid();
-        payfluxoSession->declareDownloadIntention(
-            torrent->createMagnetURI(),
-            torrent->piecesCount(),
-            torrent->id().toString()
-        );
+        // if is new, declare intention
+        if (!torrent->isCompleted()) {
+            payfluxoSession->declareDownloadIntention(
+                torrent->createMagnetURI(),
+                torrent->piecesCount(),
+                torrent->id().toString()
+            );
+        }
     }
 
     // Torrent could have error just after adding to libtorrent

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1981,7 +1981,7 @@ void TorrentImpl::handleBlockUploadedAlert(const lt::block_uploaded_alert* p)
     if (Payfluxo::Session::instance()->isAuthenticated()) {
         QString downloaderIp = QString::fromStdString(p->endpoint.address().to_string());
 
-        Payfluxo::Session::instance()->increaseIpPaymentPendent(downloaderIp);
+        Payfluxo::Session::instance()->increaseIpBlocksDownloaded(downloaderIp);
     }
 }
 

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1970,7 +1970,7 @@ void TorrentImpl::handleBlockFinishedAlert(const lt::block_finished_alert* p)
         service->sendBlockDownloadedMessage(
             QString::fromStdString(p->endpoint.address().to_string()),
             this->createMagnetURI(),
-            QString::number(this->totalSize())
+            QString::number(this->piecesCount())
         );
     }
 }

--- a/src/base/payfluxo/payfluxo.cpp
+++ b/src/base/payfluxo/payfluxo.cpp
@@ -159,4 +159,8 @@ void Session::updateWallet(float newAvailable, float newFrozen, float newRedeema
     emit walletUpdated();
 }
 
+void Session::NotifyFailed(){
+    emit NATFailed();
+}
+
 Session* Session::m_instance = nullptr;

--- a/src/base/payfluxo/payfluxo.cpp
+++ b/src/base/payfluxo/payfluxo.cpp
@@ -92,27 +92,26 @@ PayfluxoService* Session::getService() {
     return m_payfluxoService;
 }
 
-void Session::increaseIpPaymentPendent(QString ip) {
-    if (this->m_ipPaymentPendencies.contains(ip))
-        this->m_ipPaymentPendencies[ip] = 0;
-
-    this->m_ipPaymentPendencies[ip] += 1;
+void Session::setIpMadePayment(QString ip, int madePayments) {
+    this->m_ipPaymentsMade[ip] = madePayments;
 }
 
-void Session::decreaseIpPaymentPendent(QString ip) {
-    this->m_ipPaymentPendencies[ip] -= 1;
+void Session::increaseIpBlocksDownloaded(QString ip) {
+    this->m_ipBlocksDownloaded[ip]++;
 }
 
-void Session::clearIpPaymentPendency(QString ip) {
-    this->m_ipPaymentPendencies.remove(ip);
+void Session::clearIpPaymentRegistry(QString ip) {
+    this->m_ipPaymentsMade.remove(ip);
+    this->m_ipBlocksDownloaded.remove(ip);
 }
 
 bool Session::ipExceededPendentPayment(QString ip) {
-    return this->m_ipPaymentPendencies[ip] >= PENDENCE_TOLERANCE;
+    int pendentPayments = this->m_ipBlocksDownloaded[ip] - this->m_ipPaymentsMade[ip];
+    return pendentPayments >= PENDENCE_TOLERANCE;
 }
 
 int Session::getIpPendentPayment(QString ip) {
-    return this->m_ipPaymentPendencies[ip];
+    return this->m_ipBlocksDownloaded[ip] - this->m_ipPaymentsMade[ip];
 }
 
 QString Session::getCertificate() {

--- a/src/base/payfluxo/payfluxo.h
+++ b/src/base/payfluxo/payfluxo.h
@@ -41,10 +41,13 @@ namespace Payfluxo {
         void logout();
         void closePayfluxo();
 
+        void NotifyFailed();
+
         static Session* m_instance;
 
     signals:
         void walletUpdated();
+        void NATFailed();
 
     private:
         QString m_userDecryptedCertificateString;

--- a/src/base/payfluxo/payfluxo.h
+++ b/src/base/payfluxo/payfluxo.h
@@ -16,9 +16,9 @@ namespace Payfluxo {
         bool authenticate(QString password, QString certificatePath);
         bool isAuthenticated();
 
-        void increaseIpPaymentPendent(QString ip);
-        void decreaseIpPaymentPendent(QString ip);
-        void clearIpPaymentPendency(QString ip);
+        void increaseIpBlocksDownloaded(QString ip);
+        void setIpMadePayment(QString ip, int madePayments);
+        void clearIpPaymentRegistry(QString ip);
         int  getIpPendentPayment(QString ip);
         bool ipExceededPendentPayment(QString ip);
 
@@ -59,7 +59,8 @@ namespace Payfluxo {
         float m_redeemableCoins;
 
         PayfluxoService* m_payfluxoService;
-        QHash<QString, int> m_ipPaymentPendencies;
+        QHash<QString, int> m_ipPaymentsMade;
+        QHash<QString, int> m_ipBlocksDownloaded;
         bool m_authenticated;
 
         explicit Session();

--- a/src/base/payfluxo/payfluxoservice.cpp
+++ b/src/base/payfluxo/payfluxoservice.cpp
@@ -53,11 +53,11 @@ void PayfluxoService::closed() {
 
 }
 
-void PayfluxoService::handlePaymentNotification(QString ip)
+void PayfluxoService::handlePaymentNotification(QString ip, int blocksPaid)
 {
     Payfluxo::Session* session = Payfluxo::Session::instance();
 
-    session->decreaseIpPaymentPendent(ip);
+    session->setIpMadePayment(ip, blocksPaid);
     session->setRedeemableCoins(session->getRedeemableCoins() + 1);
 
     if (session->getIpPendentPayment(ip) < RECOVERY_FROM_BLACK_LIST_TOLERANCE)
@@ -97,7 +97,7 @@ void PayfluxoService::onTextMessageReceived(QString message)
     QJsonObject dataJson = jsonObject["data"].toObject();
 
     if (QString::compare(type, "PaymentNotification", Qt::CaseSensitive) == 0) {
-        this->handlePaymentNotification(dataJson["ip"].toString());
+        this->handlePaymentNotification(dataJson["payerIp"].toString(), dataJson["blocksPaid"].toInt());
     }
 
     else if (QString::compare(type, "IntentionDeclaredNotification", Qt::CaseSensitive) == 0) {

--- a/src/base/payfluxo/payfluxoservice.cpp
+++ b/src/base/payfluxo/payfluxoservice.cpp
@@ -116,6 +116,10 @@ void PayfluxoService::onTextMessageReceived(QString message)
         );
     }
 
+    else if (QString::compare(type, "NATNotifcation", Qt::CaseSensitive) == 0) {
+        Payfluxo::Session::instance()->NotifyFailed();
+    }
+
     if (m_debug)
         qDebug() << "Message received:" << message;
 

--- a/src/base/payfluxo/payfluxoservice.h
+++ b/src/base/payfluxo/payfluxoservice.h
@@ -4,7 +4,7 @@
 #include <QWebSocket>
 
 class PayfluxoService : public QObject {
-
+    Q_OBJECT
 private:
     bool m_debug;
     QWebSocket m_webSocket;

--- a/src/base/payfluxo/payfluxoservice.h
+++ b/src/base/payfluxo/payfluxoservice.h
@@ -10,7 +10,7 @@ private:
     QWebSocket m_webSocket;
     void sendMessage(QString message);
 
-    void handlePaymentNotification(QString ip);
+    void handlePaymentNotification(QString ip, int blocksPaid);
     void handleIntentionDeclaredNotification(QString torrentIdString, int status);
     void handleWalletNotification(float newAvailable, float newFrozen, float newRedeemable);
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -753,11 +753,13 @@ void MainWindow::on_actionAuth_triggered()
                 else
                 {
                     torrents[index]->turnTorrentPaid();
-                    Payfluxo::Session::instance()->declareDownloadIntention(
-                        torrents[index]->createMagnetURI(),
-                        torrents[index]->piecesCount(),
-                        torrents[index]->id().toString()
-                    );
+                    if (!torrents[index]->isCompleted()) {
+                        Payfluxo::Session::instance()->declareDownloadIntention(
+                            torrents[index]->createMagnetURI(),
+                            torrents[index]->piecesCount(),
+                            torrents[index]->id().toString()
+                        );
+                    }
                 }
             }
             if (!notPaidTorrents.empty())

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -222,6 +222,8 @@ MainWindow::MainWindow(QWidget *parent)
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::speedLimitModeChanged, this, &MainWindow::updateAltSpeedsBtn);
     connect(BitTorrent::Session::instance(), &BitTorrent::Session::recursiveTorrentDownloadPossible, this, &MainWindow::askRecursiveTorrentDownloadConfirmation);
 
+    connect(Payfluxo::Session::instance(), &Payfluxo::Session::NATFailed, this, &MainWindow::NATerror);
+
     qDebug("create tabWidget");
     m_tabs = new HidableTabWidget(this);
     connect(m_tabs.data(), &QTabWidget::currentChanged, this, &MainWindow::tabChanged);
@@ -651,6 +653,12 @@ void MainWindow::toolbarFollowSystem()
 {
     m_ui->toolBar->setToolButtonStyle(Qt::ToolButtonFollowStyle);
     Preferences::instance()->setToolbarTextPosition(Qt::ToolButtonFollowStyle);
+}
+
+void MainWindow::NATerror() {
+    QMessageBox NATErrorDialogBox;
+    NATErrorDialogBox.setText("Payfluxo failed to open port 9003 on router. Please, open this port manually on your router");
+    NATErrorDialogBox.exec();
 }
 
 bool MainWindow::defineUIAuth()

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -107,6 +107,7 @@ public:
     void showNotificationBaloon(const QString &title, const QString &msg) const;
 
 private slots:
+    void NATerror();
     void showFilterContextMenu(const QPoint &);
     void balloonClicked();
     void writeSettings();

--- a/src/gui/paychoicedialog.cpp
+++ b/src/gui/paychoicedialog.cpp
@@ -89,11 +89,13 @@ void PayChoiceDialog::onSelectButtonClicked()
         if (torrentState == Qt::CheckState::Checked)
         {
             torrentOptions[i]->turnTorrentPaid();
-            Payfluxo::Session::instance()->declareDownloadIntention(
-                torrentOptions[i]->createMagnetURI(),
-                torrentOptions[i]->piecesCount(),
-                torrentOptions[i]->id().toString()
-            );
+            if (!torrentOptions[i]->isCompleted()) {
+                Payfluxo::Session::instance()->declareDownloadIntention(
+                    torrentOptions[i]->createMagnetURI(),
+                    torrentOptions[i]->piecesCount(),
+                    torrentOptions[i]->id().toString()
+                );
+            }
         }
     }
 


### PR DESCRIPTION
- Sends pieces count instead of file size to payfluxo;
- Just declare download intention if torrent is new;
- Pops NAT error dialog box for user;
- Changes payment pendence calculation by tracking blocks downloaded and payments received;